### PR TITLE
Fixes for environment accessor expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aethergames/mkscribe",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Portable AST Generator for the Scribe interpreted language written in TypeScript.",
 	"main": "out/init.lua",
 	"scripts": {

--- a/src/mkscribe/ast/types.d.ts
+++ b/src/mkscribe/ast/types.d.ts
@@ -109,7 +109,7 @@ export interface ExpressionVisitor<R> {
 	visitUnaryExpression(expr: UnaryExpression): R;
 	visitTernaryExpression(expr: TernaryExpression): R;
 	visitVariableExpression(expr: VariableExpression): R;
-	visitEnviromentAccessor(expr: EnvironmentAccessor): R;
+	visitEnvironmentAccessor(expr: EnvironmentAccessor): R;
 	visitLiteralExpression(expr: LiteralExpression): R;
 	visitGroupingExpression(expr: GroupingExpression): R;
 	visitArrayExpression(expr: ArrayExpression): R;

--- a/src/mkscribe/parser/index.ts
+++ b/src/mkscribe/parser/index.ts
@@ -487,6 +487,7 @@ export class Parser implements ParserImplementation {
 			_default = true;
 		}
 
+		this.consume(TokenType.SCENE, "Did you meant to define a default scene.");
 		const name = this.consume(TokenType.IDENTIFIER, "Expected a scene identifier.");
 
 		this.consume(TokenType.L_B, `Expected "{" after a scene for the body start.`);


### PR DESCRIPTION
Some changes were made on the typos, which led to silent errors on the interpreter. 

This PR will be merged immediately as it's breaking changes for Scribe. 