### PR TITLE
Scene fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aethergames/mkscribe",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Portable AST Generator for the Scribe interpreted language written in TypeScript.",
 	"main": "out/init.lua",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aethergames/mkscribe",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Portable AST Generator for the Scribe interpreted language written in TypeScript.",
 	"main": "out/init.lua",
 	"scripts": {

--- a/src/mkscribe/ast/types.d.ts
+++ b/src/mkscribe/ast/types.d.ts
@@ -109,7 +109,7 @@ export interface ExpressionVisitor<R> {
 	visitUnaryExpression(expr: UnaryExpression): R;
 	visitTernaryExpression(expr: TernaryExpression): R;
 	visitVariableExpression(expr: VariableExpression): R;
-	visitEnviromentAccessor(expr: EnvironmentAccessor): R;
+	visitEnvironmentAccessor(expr: EnvironmentAccessor): R;
 	visitLiteralExpression(expr: LiteralExpression): R;
 	visitGroupingExpression(expr: GroupingExpression): R;
 	visitArrayExpression(expr: ArrayExpression): R;

--- a/src/mkscribe/parser/index.ts
+++ b/src/mkscribe/parser/index.ts
@@ -484,10 +484,10 @@ export class Parser implements ParserImplementation {
 
 		let _default: boolean | undefined;
 		if (previous.type === TokenType.DEFAULT) {
+			this.consume(TokenType.SCENE, "Did you meant to define a default scene.");
 			_default = true;
 		}
 
-		this.consume(TokenType.SCENE, "Did you meant to define a default scene.");
 		const name = this.consume(TokenType.IDENTIFIER, "Expected a scene identifier.");
 
 		this.consume(TokenType.L_B, `Expected "{" after a scene for the body start.`);

--- a/src/mkscribe/parser/index.ts
+++ b/src/mkscribe/parser/index.ts
@@ -487,6 +487,7 @@ export class Parser implements ParserImplementation {
 			_default = true;
 		}
 
+		this.consume(TokenType.SCENE, "Did you meant to define a default scene.");
 		const name = this.consume(TokenType.IDENTIFIER, "Expected a scene identifier.");
 
 		this.consume(TokenType.L_B, `Expected "{" after a scene for the body start.`);


### PR DESCRIPTION
Fixes for default scenes and normal scenes being confused. 

Example:
```scribe
scene NAME {} # It throws an error saying "Did you meant a default scene?"
default scene NAME {} # Unique way of defining scenes, this is now fixed.
```
