### PR TITLE
feat(parser) & meta(versioning): added exit as an expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aethergames/mkscribe",
-	"version": "0.3.1",
+	"version": "0.3.1-beta.1",
 	"description": "Portable AST Generator for the Scribe interpreted language written in TypeScript.",
 	"main": "out/init.lua",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aethergames/mkscribe",
-	"version": "0.3.1-beta.1",
+	"version": "0.3.2-beta.1",
 	"description": "Portable AST Generator for the Scribe interpreted language written in TypeScript.",
 	"main": "out/init.lua",
 	"scripts": {

--- a/src/mkscribe/ast/types.d.ts
+++ b/src/mkscribe/ast/types.d.ts
@@ -113,6 +113,7 @@ export interface ExpressionVisitor<R> {
 	visitArrayExpression(expr: ArrayExpression): R;
 	visitMetadataExpression(expr: MetadataExpression): R;
 	visitStartExpression(expr: StartExpression): R;
+	visitExitExpression(expr: ExitExpression): R;
 }
 
 interface ExpressionStatement extends Statement {

--- a/src/mkscribe/parser/index.ts
+++ b/src/mkscribe/parser/index.ts
@@ -8,6 +8,7 @@ import {
 	DoStatement,
 	EchoStatement,
 	EnvironmentAccessor,
+	ExitExpression,
 	Expression,
 	ExpressionStatement,
 	GroupingExpression,
@@ -123,6 +124,10 @@ export class Parser implements ParserImplementation {
 
 		if (this.match(TokenType.ENV)) {
 			return this.accessor();
+		}
+
+		if (this.match(TokenType.EXIT)) {
+			return this.exit();
 		}
 
 		const expr = this.expression();
@@ -293,6 +298,10 @@ export class Parser implements ParserImplementation {
 		const objective = this.consume(TokenType.IDENTIFIER, `Expected an objective identifier to start!`);
 
 		return newExpression(ExpressionType.START, { objective });
+	}
+
+	private exit(): ExitExpression {
+		return newExpression(ExpressionType.EXIT, { value: this.express() });
 	}
 
 	/** Statements */


### PR DESCRIPTION
Added exit expression. 

```ts
import { Scribe } from "@aethergames/scribe";

const ScribeRuntime = Scribe.load(
    `
    exit "Hello, world!"

    echo "Hello, world from the other side!" # Will be ignored

`,
    {},
);

ScribeRuntime.onExit = ({ output }) => print(output); // Hello, world!

ScribeRuntime.start();
```

More to come.