### PR TITLE
fix(parser): if statements diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aethergames/mkscribe",
-	"version": "0.3.2-beta.1",
+	"version": "0.3.3-beta.1",
 	"description": "Portable AST Generator for the Scribe interpreted language written in TypeScript.",
 	"main": "out/init.lua",
 	"scripts": {

--- a/src/mkscribe/parser/index.ts
+++ b/src/mkscribe/parser/index.ts
@@ -464,17 +464,13 @@ export class Parser implements ParserImplementation {
 			condition = this.express();
 		}
 
-		let body: BlockStatement;
+		const body: BlockStatement = this.block(`Expected "{" after an if`);
+
 		let elseBody: BlockStatement | undefined;
-
 		if (condition !== undefined) {
-			body = this.block(`Expected "{" after a -> for the body start.`);
-
 			if (this.match(TokenType.ELSE)) {
 				elseBody = this.block(`Expected "{" after an else for the body start.`);
 			}
-		} else {
-			body = this.block(`Expected "{" after an if`);
 		}
 
 		return newStatement(StatementType.IF, { condition, body, else: elseBody });


### PR DESCRIPTION
Little design change, it doesn't break current Scribe programs since it was already broken haha. 

Now if statements are required to be written this way:
```scribe
if { ... }

if (...) { ... }
```

No more `->` for differentiating between one and another.