### PR TITLE
feat: otherwise statement

### DIFF
--- a/src/mkscribe/ast/index.ts
+++ b/src/mkscribe/ast/index.ts
@@ -25,6 +25,7 @@ export enum StatementType {
 	DO = "DoStatement",
 	DIALOGUE = "DialogueStatement",
 	CONDITION = "ConditionStatement",
+	OTHERWISE = "OtherwiseStatement",
 	IF = "IfStatement",
 	SCENE = "SceneStatement",
 	OPTION = "OptionStatement",
@@ -53,7 +54,6 @@ export function newExpression<T extends ExpressionType>(
 		 * type.
 		 *
 		 * @param visitor the visitor (the resolver for the different expressions)
-		 * @returns whatever the visitor may return.
 		 */
 		accept<R>(visitor: ExpressionVisitor<R>): R {
 			return visitor[`visit${exprType}` as keyof ExpressionVisitor<R>](this as never);
@@ -83,7 +83,6 @@ export function newStatement<T extends StatementType>(
 		 * type.
 		 *
 		 * @param visitor the visitor (the resolver for the different statements)
-		 * @returns whatever the visitor may return.
 		 */
 		accept<R>(visitor: StatementVisitor<R>): R {
 			return visitor[`visit${stmtType}` as keyof StatementVisitor<R>](this);

--- a/src/mkscribe/ast/types.d.ts
+++ b/src/mkscribe/ast/types.d.ts
@@ -195,10 +195,19 @@ interface DoStatement extends Statement {
 interface ConditionStatement extends Statement {
 	/**
 	 * condition -> {
-	 * 	...body (either a nested condition or whatever)
+	 * 	...body
 	 * }
 	 */
 	condition: Expression;
+	body: Statement;
+}
+
+interface OtherwiseStatement extends Statement {
+	/**
+	 * otherwise -> {
+	 * 	...body
+	 * }
+	 */
 	body: Statement;
 }
 
@@ -208,14 +217,20 @@ interface IfStatement extends Statement {
 	 * 	...body (either a nested if or whatever you may want to have here)
 	 * }
 	 *
-	 * if {
-	 * 	...body (conditions, if not, it will throw an error)
-	 * }
-	 *
 	 * if condition -> {
 	 * 	...body
 	 * } else {
 	 * 	...body
+	 * }
+	 *
+	 * if {
+	 * 	condition -> {
+	 * 		...body
+	 * 	}
+	 *
+	 * 	otherwise -> { // Optional otherwise (behaves as an else)
+	 * 		...body
+	 * 	}
 	 * }
 	 */
 	condition: Expression | undefined;
@@ -286,6 +301,7 @@ export interface Statements {
 	DoStatement: DoStatement;
 	DialogueStatement: DialogueStatement;
 	ConditionStatement: ConditionStatement;
+	OtherwiseStatement: OtherwiseStatement;
 	IfStatement: IfStatement;
 	SceneStatement: SceneStatement;
 	OptionStatement: OptionStatement;
@@ -309,7 +325,6 @@ export interface StatementVisitor<R> {
 	visitBlockStatement(stmt: BlockStatement): R;
 	visitDoStatement(stmt: DoStatement): R;
 	visitDialogueStatement(stmt: DialogueStatement): R;
-	visitConditionStatement(stmt: ConditionStatement): R;
 	visitIfStatement(stmt: IfStatement): R;
 	visitSceneStatement(stmt: SceneStatement): R;
 	visitOptionStatement(stmt: OptionStatement): R;

--- a/src/mkscribe/parser/index.ts
+++ b/src/mkscribe/parser/index.ts
@@ -17,6 +17,7 @@ import {
 	LiteralExpression,
 	MetadataExpression,
 	OptionStatement,
+	OtherwiseStatement,
 	SceneStatement,
 	StartExpression,
 	Statement,
@@ -349,6 +350,10 @@ export class Parser implements ParserImplementation {
 			return this.option();
 		}
 
+		if (this.match(TokenType.OTHERWISE)) {
+			return this.otherwise();
+		}
+
 		if (this.match(TokenType.TRIGGER)) {
 			return this.trigger();
 		}
@@ -366,7 +371,7 @@ export class Parser implements ParserImplementation {
 		}
 
 		if (this.match(TokenType.DEFAULT)) {
-			if (this.match(TokenType.OBJECTIVE)) {
+			if (this.consume(TokenType.OBJECTIVE, "You can only set objectives to be default.")) {
 				return this.declaration(StatementType.OBJECTIVE, true, true);
 			}
 		}
@@ -445,6 +450,14 @@ export class Parser implements ParserImplementation {
 	private condition(condition: Expression): ConditionStatement {
 		return newStatement(StatementType.CONDITION, {
 			condition,
+			body: this.block(`Expected "{" after -> to start a condition's body.`),
+		});
+	}
+
+	private otherwise(): OtherwiseStatement {
+		this.consume(TokenType.CONTINUE, "Expected -> after otherwise to start it's body.");
+
+		return newStatement(StatementType.OTHERWISE, {
 			body: this.block(`Expected "{" after -> to start a condition's body.`),
 		});
 	}

--- a/src/mkscribe/scanner/utils/index.ts
+++ b/src/mkscribe/scanner/utils/index.ts
@@ -65,8 +65,7 @@ export enum TokenType {
 
 	// Special characters
 	ENV = "EnviromentAccessor",
-
-	EOF = "End_of_file", // this is kinda necessary at the moment to tell the tokenizer when the end has been reached
+	EOF = "EndOfFile",
 }
 
 export const Keywords = {


### PR DESCRIPTION
Small design change (doesn't interfere with already functional code). 

Introducing `otherwise` keyword within `if-statements`. En example;

```scribe
if {
    myCondition -> {
        ...body
    }

    otherwise -> {
        ...body
    }
}
```

If every branch before `otherwise` (not any other can be declared after it) doesn't evaluate to a truth value, it will resolve `otherwise`. It works same as an `else`, or as a `_` in Rust. 